### PR TITLE
Add unit tests and CI pipeline for Python 3.9-3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
+
+    - name: Install dependencies
+      run: |
+        uv pip install --system -e ".[test]"
+
+    - name: Run tests
+      run: |
+        pytest tests/ -v --tb=short

--- a/fastapi_toolbox/database.py
+++ b/fastapi_toolbox/database.py
@@ -1,5 +1,6 @@
 from typing import Optional, Generator, Any
-from sqlmodel import Session, SQLModel, create_engine, Engine
+from sqlalchemy.engine import Engine
+from sqlmodel import Session, SQLModel, create_engine
 
 from .settings import settings, Settings
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,11 @@ classifiers = [
 ]
 keywords = ["fastapi", "starlette", "web", "utilities"]
 
+[project.optional-dependencies]
+test = [
+    "pytest>=7.0.0",
+]
+
 [project.urls]
 Homepage = "https://github.com/wynemo/fastapi-utils"
 Repository = "https://github.com/wynemo/fastapi-utils.git"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests package

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+import pytest
+import os
+from unittest.mock import patch
+
+
+@pytest.fixture(autouse=True)
+def reset_database_engine():
+    """Reset database engine before each test"""
+    import fastapi_toolbox.database as db_module
+    db_module._engine = None
+    yield
+    db_module._engine = None
+
+
+@pytest.fixture
+def temp_env_file(tmp_path):
+    """Create a temporary .env file for testing"""
+    env_file = tmp_path / ".env"
+    return env_file
+
+
+@pytest.fixture
+def mock_env_vars():
+    """Fixture to mock environment variables"""
+    with patch.dict(os.environ, {}, clear=False):
+        yield

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,158 @@
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+from sqlmodel import SQLModel, Field, Session
+
+
+class TestInitDatabase:
+    """Tests for init_database function"""
+
+    def test_init_database_with_direct_url(self):
+        """Test init_database with direct database_url parameter"""
+        from fastapi_toolbox.database import init_database
+
+        url = "sqlite:///test_direct.db"
+        engine = init_database(database_url=url)
+
+        assert engine is not None
+        assert str(engine.url) == url
+
+    def test_init_database_with_settings_instance(self):
+        """Test init_database with custom Settings instance"""
+        from fastapi_toolbox.database import init_database
+        from fastapi_toolbox.settings import Settings
+
+        with patch.dict(os.environ, {}, clear=True):
+            class CustomSettings(Settings):
+                DATABASE_URL: str = "sqlite:///test_settings.db"
+
+            custom_settings = CustomSettings(_env_file=None)
+            engine = init_database(settings_instance=custom_settings)
+
+            assert engine is not None
+            assert str(engine.url) == "sqlite:///test_settings.db"
+
+    def test_init_database_url_priority_over_settings(self):
+        """Test that direct URL takes priority over settings instance"""
+        from fastapi_toolbox.database import init_database
+        from fastapi_toolbox.settings import Settings
+
+        with patch.dict(os.environ, {}, clear=True):
+            class CustomSettings(Settings):
+                DATABASE_URL: str = "sqlite:///settings.db"
+
+            custom_settings = CustomSettings(_env_file=None)
+            direct_url = "sqlite:///direct.db"
+
+            engine = init_database(
+                database_url=direct_url,
+                settings_instance=custom_settings
+            )
+
+            assert str(engine.url) == direct_url
+
+    def test_init_database_with_engine_kwargs(self):
+        """Test init_database passes kwargs to create_engine"""
+        from fastapi_toolbox.database import init_database
+
+        engine = init_database(
+            database_url="sqlite:///test_kwargs.db",
+            echo=True
+        )
+
+        assert engine is not None
+        assert engine.echo is True
+
+
+class TestGetEngine:
+    """Tests for get_engine function"""
+
+    def test_get_engine_returns_initialized_engine(self):
+        """Test get_engine returns the initialized engine"""
+        from fastapi_toolbox.database import init_database, get_engine
+
+        init_database(database_url="sqlite:///test_get.db")
+        engine = get_engine()
+
+        assert engine is not None
+        assert str(engine.url) == "sqlite:///test_get.db"
+
+    def test_get_engine_auto_initializes(self):
+        """Test get_engine auto-initializes if engine is None"""
+        from fastapi_toolbox.database import get_engine
+        import fastapi_toolbox.database as db_module
+
+        db_module._engine = None
+
+        with patch.object(db_module, 'init_database') as mock_init:
+            mock_engine = MagicMock()
+            mock_init.return_value = mock_engine
+            db_module._engine = None
+
+            def set_engine():
+                db_module._engine = mock_engine
+                return mock_engine
+
+            mock_init.side_effect = set_engine
+
+            engine = get_engine()
+            mock_init.assert_called_once()
+
+
+class TestGetSession:
+    """Tests for get_session function"""
+
+    def test_get_session_yields_session(self):
+        """Test get_session yields a valid Session"""
+        from fastapi_toolbox.database import init_database, get_session
+
+        init_database(database_url="sqlite:///:memory:")
+
+        session_gen = get_session()
+        session = next(session_gen)
+
+        assert isinstance(session, Session)
+
+        try:
+            next(session_gen)
+        except StopIteration:
+            pass
+
+    def test_get_session_closes_session(self):
+        """Test get_session properly closes the session"""
+        from fastapi_toolbox.database import init_database, get_session
+
+        init_database(database_url="sqlite:///:memory:")
+
+        session_gen = get_session()
+        session = next(session_gen)
+
+        try:
+            next(session_gen)
+        except StopIteration:
+            pass
+
+
+class TestCreateDbAndTables:
+    """Tests for create_db_and_tables function"""
+
+    def test_create_db_and_tables(self):
+        """Test create_db_and_tables creates tables"""
+        from fastapi_toolbox.database import init_database, create_db_and_tables
+
+        class TestModel(SQLModel, table=True):
+            __tablename__ = "test_model_table"
+            id: int = Field(default=None, primary_key=True)
+            name: str
+
+        init_database(database_url="sqlite:///:memory:")
+        create_db_and_tables()
+
+    def test_create_db_and_tables_idempotent(self):
+        """Test create_db_and_tables can be called multiple times"""
+        from fastapi_toolbox.database import init_database, create_db_and_tables
+
+        init_database(database_url="sqlite:///:memory:")
+
+        create_db_and_tables()
+        create_db_and_tables()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,109 @@
+import pytest
+
+
+class TestPackageImports:
+    """Tests for package imports from fastapi_toolbox"""
+
+    def test_import_static_files_cache(self):
+        """Test StaticFilesCache can be imported"""
+        from fastapi_toolbox import StaticFilesCache
+
+        assert StaticFilesCache is not None
+
+    def test_import_uvicorn_config(self):
+        """Test UvicornConfig can be imported"""
+        from fastapi_toolbox import UvicornConfig
+
+        assert UvicornConfig is not None
+
+    def test_import_logging_components(self):
+        """Test logging components can be imported"""
+        from fastapi_toolbox import (
+            logger,
+            setup_logging,
+            add_file_log,
+            InterceptHandler,
+            Rotator,
+            get_log_level,
+            LOG_LEVEL,
+            JSON_LOGS
+        )
+
+        assert logger is not None
+        assert setup_logging is not None
+        assert add_file_log is not None
+        assert InterceptHandler is not None
+        assert Rotator is not None
+        assert get_log_level is not None
+
+    def test_import_run_server(self):
+        """Test run_server can be imported"""
+        from fastapi_toolbox import run_server
+
+        assert run_server is not None
+
+    def test_import_middleware(self):
+        """Test NextJSRouteMiddleware can be imported"""
+        from fastapi_toolbox import NextJSRouteMiddleware
+
+        assert NextJSRouteMiddleware is not None
+
+    def test_import_settings(self):
+        """Test Settings and settings can be imported"""
+        from fastapi_toolbox import Settings, settings
+
+        assert Settings is not None
+        assert settings is not None
+
+    def test_import_database_components(self):
+        """Test database components can be imported"""
+        from fastapi_toolbox import (
+            init_database,
+            get_engine,
+            get_session,
+            create_db_and_tables
+        )
+
+        assert init_database is not None
+        assert get_engine is not None
+        assert get_session is not None
+        assert create_db_and_tables is not None
+
+
+class TestAllExports:
+    """Tests for __all__ exports"""
+
+    def test_all_exports_exist(self):
+        """Test all items in __all__ are actually exported"""
+        import fastapi_toolbox
+
+        expected_exports = [
+            "StaticFilesCache",
+            "UvicornConfig",
+            "logger",
+            "setup_logging",
+            "add_file_log",
+            "InterceptHandler",
+            "Rotator",
+            "get_log_level",
+            "LOG_LEVEL",
+            "JSON_LOGS",
+            "run_server",
+            "NextJSRouteMiddleware",
+            "Settings",
+            "settings",
+            "init_database",
+            "get_engine",
+            "get_session",
+            "create_db_and_tables"
+        ]
+
+        for export in expected_exports:
+            assert hasattr(fastapi_toolbox, export), f"{export} not found in fastapi_toolbox"
+
+    def test_all_matches_expected(self):
+        """Test __all__ contains expected items"""
+        import fastapi_toolbox
+
+        assert hasattr(fastapi_toolbox, '__all__')
+        assert len(fastapi_toolbox.__all__) == 18

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,65 @@
+import os
+import pytest
+from unittest.mock import patch
+
+
+class TestSettings:
+    """Tests for Settings class"""
+
+    def test_default_database_url(self):
+        """Test that Settings has default DATABASE_URL"""
+        from fastapi_toolbox.settings import Settings
+
+        with patch.dict(os.environ, {}, clear=True):
+            settings = Settings(_env_file=None)
+            assert settings.DATABASE_URL == "postgresql://user:password@localhost:5432/db"
+
+    def test_database_url_from_env(self):
+        """Test that Settings loads DATABASE_URL from environment variable"""
+        from fastapi_toolbox.settings import Settings
+
+        custom_url = "postgresql://custom:pass@myhost:5432/mydb"
+        with patch.dict(os.environ, {"DATABASE_URL": custom_url}, clear=True):
+            settings = Settings(_env_file=None)
+            assert settings.DATABASE_URL == custom_url
+
+    def test_settings_inheritance(self):
+        """Test that Settings can be inherited with custom defaults"""
+        from fastapi_toolbox.settings import Settings
+
+        class CustomSettings(Settings):
+            DATABASE_URL: str = "sqlite:///custom.db"
+            CUSTOM_FIELD: str = "custom_value"
+
+        with patch.dict(os.environ, {}, clear=True):
+            custom_settings = CustomSettings(_env_file=None)
+            assert custom_settings.DATABASE_URL == "sqlite:///custom.db"
+            assert custom_settings.CUSTOM_FIELD == "custom_value"
+
+    def test_settings_env_override_inheritance(self):
+        """Test that env vars override inherited defaults"""
+        from fastapi_toolbox.settings import Settings
+
+        class CustomSettings(Settings):
+            DATABASE_URL: str = "sqlite:///custom.db"
+
+        env_url = "postgresql://env:pass@envhost:5432/envdb"
+        with patch.dict(os.environ, {"DATABASE_URL": env_url}, clear=True):
+            custom_settings = CustomSettings(_env_file=None)
+            assert custom_settings.DATABASE_URL == env_url
+
+
+class TestDefaultSettingsInstance:
+    """Tests for the default settings instance"""
+
+    def test_settings_instance_exists(self):
+        """Test that a default settings instance is exported"""
+        from fastapi_toolbox.settings import settings
+
+        assert settings is not None
+
+    def test_settings_instance_type(self):
+        """Test that the default settings instance is of correct type"""
+        from fastapi_toolbox.settings import settings, Settings
+
+        assert isinstance(settings, Settings)


### PR DESCRIPTION
- Add unit tests for settings.py, database.py, and __init__.py
- Create GitHub Actions workflow for testing across Python 3.9-3.14
- Fix Engine import in database.py (import from sqlalchemy.engine)
- Add pytest as test dependency in pyproject.toml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated continuous integration testing across Python 3.9–3.14 via GitHub Actions.
  * Added optional test dependencies installable via test extras.

* **Tests**
  * Added comprehensive test suite validating database initialization, engine management, session provisioning, and table creation.
  * Added package import and export validation tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->